### PR TITLE
feat(file): normalize citation paths and add /v1/file contract test

### DIFF
--- a/app/paths.py
+++ b/app/paths.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional, Tuple
+from .config import settings
+
+class PathResolutionError(ValueError):
+    pass
+
+RAW_PREFIXES = ("data/raw/", "raw/")
+CLEAN_PREFIXES = ("data/clean/", "clean/")
+
+def _strip_anchor(p: str) -> tuple[str, Optional[str]]:
+    if "#" in p:
+        base, anchor = p.split("#", 1)
+        return base, anchor
+    return p, None
+
+def _within(root: Path, candidate: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+        return True
+    except Exception:
+        return False
+
+def normalize_source_path(source_path: str) -> Tuple[Path, Optional[str]]:
+    """
+    Normalize a citation/source path into a real file under one of the allowed roots.
+
+    Accepts:
+      - raw-relative (e.g., "handbook/performance.md")
+      - clean-relative (e.g., "chunks/handbook/performance.md")
+      - 'data/raw/...'
+      - 'data/clean/...'
+      - 'raw/...'
+      - 'clean/...'
+
+    Returns (resolved_path, anchor) or raises PathResolutionError.
+    """
+    if not source_path or source_path.strip() == "":
+        raise PathResolutionError("Empty source_path")
+
+    base, anchor = _strip_anchor(source_path.strip())
+    # normalize slashes & remove leading slashes
+    norm = Path(base.lstrip("/")).as_posix()
+
+    # Case 1: explicit raw/clean prefix — strip and join to the correct root
+    for pref in RAW_PREFIXES:
+        if norm.startswith(pref):
+            tail = norm[len(pref):]
+            candidate = (settings.DATA_RAW_DIR / tail).resolve()
+            if candidate.exists() and candidate.is_file() and _within(settings.DATA_RAW_DIR.resolve(), candidate):
+                return candidate, anchor
+            raise PathResolutionError(f"Could not resolve path under raw: {source_path}")
+
+    for pref in CLEAN_PREFIXES:
+        if norm.startswith(pref):
+            tail = norm[len(pref):]
+            candidate = (settings.DATA_CLEAN_DIR / tail).resolve()
+            if candidate.exists() and candidate.is_file() and _within(settings.DATA_CLEAN_DIR.resolve(), candidate):
+                return candidate, anchor
+            raise PathResolutionError(f"Could not resolve path under clean: {source_path}")
+
+    # Case 2: unknown prefix — try as raw-relative and clean-relative
+    raw_try = (settings.DATA_RAW_DIR / norm).resolve()
+    if raw_try.exists() and raw_try.is_file() and _within(settings.DATA_RAW_DIR.resolve(), raw_try):
+        return raw_try, anchor
+
+    clean_try = (settings.DATA_CLEAN_DIR / norm).resolve()
+    if clean_try.exists() and clean_try.is_file() and _within(settings.DATA_CLEAN_DIR.resolve(), clean_try):
+        return clean_try, anchor
+
+    raise PathResolutionError(f"Could not resolve path: {source_path}")

--- a/docs/AskHR-SoT.txt
+++ b/docs/AskHR-SoT.txt
@@ -1,0 +1,77 @@
+AskHR — Source of Truth (SoT)
+Last updated: 2025-09-17 15:39
+
+VISION
+AskHR is a local‑first HR copilot that answers with receipts. It ingests your HR
+content, retrieves relevant passages (Chroma + embeddings), and uses an
+Ollama‑hosted LLM to generate concise, CPO‑caliber guidance with clickable citations.
+Primary day‑one value: trustworthy, grounded answers to common HR needs.
+
+PRODUCT MODULES
+• Module 1 (CORE, now): Ask HR — Chat with RAG
+  Purpose: Pull & synthesize answers from the HR corpus through a pragmatic CPO persona.
+  Likely hero use cases: (a) Low performance; (b) Onboarding a new hire.
+• Module 2 (NEXT): PIP Builder
+  Purpose: Turn answers about performance standards into a structured PIP draft with preserved citations.
+• Module 3 (NEXT): 30/60/90 Plan Builder
+  Purpose: Convert onboarding advice into a structured plan with goals, activities, metrics.
+• Module 4 (LATER): HR Metrics Dashboard
+  Purpose: Upload CSVs and auto‑compute core HR metrics (demographics, heatmaps,
+  attrition, time‑to‑hire, etc.). NOTE: current screenshots are mockups; the live UI is
+  intentionally minimal and unthemed.
+
+CURRENT STATE (as‑built)
+Stack
+  • Backend: FastAPI service (Python) with /v1/ask, /v1/search, /health.
+  • Retrieval: Chroma vector store; ingestion scripts create token‑based chunks with metadata.
+  • Models: Ollama (e.g., llama3.1:8b for chat; nomic‑embed‑text for embeddings).
+  • UI: Streamlit app for chat and controls (k, grounded_only).
+
+What works
+  • Grounded answers: Top‑k retrieved chunks are injected into the prompt; answers include real citations.
+  • Grounded‑only: If enabled and no sources match, API returns “No relevant sources…” (no LLM call).
+  • Evaluation harness: Fixed and runnable with sample cases; results saved locally.
+  • Observability: Structured JSON logs with request IDs; timeouts on Ollama calls.
+  • Safer models: No mutable default lists; session memory is opt‑in and scoped.
+  • Docs/Makefile: Updated so a new clone can ingest, index, run API/UI, and run eval.
+
+Gaps / Risks
+  • Retrieval tuning: Verify fallback sorter; keep MMR + synonym expansion tunables.
+  • Citation paths: Normalize all source_path variants so /v1/file links always resolve.
+  • Design system: No real typography/spacing/color tokens yet; current UI is functional only.
+  • Performance: P95 latency targets not yet measured at larger scale.
+  • Packaging: “Appliance” one‑command setup exists but needs hardening for a clean macOS run.
+  • Security: CORS permissive for localhost; document expectations if binding beyond loopback.
+
+ARCHITECTURE (mental model)
+Streamlit UI  →  FastAPI (/v1/ask, /v1/search)
+                       ↘  Retriever (embeddings + Chroma)
+                        ↘  Prompt Composer (inject top‑k chunks)
+                         ↘  Ollama Chat (answers with citations)
+Data flow: data/raw → ingest_* → data/clean (chunked + metadata) → index/ (Chroma) → retrieval → prompt → answer + citations.
+
+WORKING STYLE (Copilot operating mode)
+We prompt Copilot as our senior implementation engineer. You (PM) paste one prompt
+at a time; Copilot executes and returns a code‑review. Only full‑file replacements are
+allowed for copy/paste; no manual line edits. After you say “done,” I provide the next prompt.
+
+NEAR‑TERM EXECUTION PLAN (ordered)
+1) Retrieval trust: Normalize citation paths; add a contract test for /v1/file.
+2) Eval as guardrail: make eval.sample prints metrics (citation rate, groundedness); set minimum thresholds.
+3) Appliance hardening: one‑command fresh‑clone run (make up or ./run.sh) + seed sample pack + health checks.
+4) UI truth & polish: Helpful empty/loading/error states; “Copy with citations”; grounded‑only UX.
+5) Thin build modules: PIP Builder + 30/60/90 pages call /v1/ask and render exportable drafts (preserve citations).
+6) Design system lite: type scale, spacing tokens, neutral surface, focus rings; basic theme variables.
+
+DEFINITION OF DONE (v1)
+• ≥95% of answers include ≥1 valid, clickable citation.
+• P95 ask latency < 3.5s on M‑series Mac with sample pack.
+• make eval.sample completes and writes metrics artifacts.
+• make up succeeds on a clean machine; sample prompts appear on first run.
+• README reflects real behavior; troubleshooting includes ports/models; no telemetry spam.
+
+FUTURE FOCUS (after v1)
+• Deeper retrieval quality work (domain synonyms, rerankers, section‑aware links).
+• HR Metrics Dashboard CSV uploader + charts (demographics, heatmaps, attrition, time‑to‑hire).
+• Export pathways (Markdown/Word/Google Doc) with preserved citations.
+• Optional cloud model/provider switch with explicit privacy controls.

--- a/tests/test_paths_and_file_endpoint.py
+++ b/tests/test_paths_and_file_endpoint.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+import os
+import importlib
+import types
+import pytest
+
+def write(p: Path, content: str):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+@pytest.fixture()
+def temp_data_dirs(tmp_path, monkeypatch):
+    raw = tmp_path / "raw_root"
+    clean = tmp_path / "clean_root"
+    raw.mkdir()
+    clean.mkdir()
+    monkeypatch.setenv("DATA_RAW_DIR", str(raw))
+    monkeypatch.setenv("DATA_CLEAN_DIR", str(clean))
+    return raw, clean
+
+def test_normalize_and_file_endpoint(temp_data_dirs):
+    raw, clean = temp_data_dirs
+
+    # Create a file in raw and a different file in clean
+    raw_file_rel = Path("handbook/performance.md")
+    clean_file_rel = Path("chunks/handbook/performance.md")
+
+    write(raw / raw_file_rel, "# PIP Policy\n- 30 to 60 days\n")
+    write(clean / clean_file_rel, "Chunked content here\n")
+
+    # Reload app modules with new env
+    app_module = importlib.import_module("app.main")
+    importlib.reload(app_module)
+    from app.paths import normalize_source_path
+
+    # Normalizer resolves raw-relative
+    resolved, anchor = normalize_source_path(str(raw_file_rel))
+    assert resolved.exists()
+    assert anchor is None
+
+    # Normalizer resolves with explicit clean prefix
+    resolved2, anchor2 = normalize_source_path(f"data/clean/{clean_file_rel.as_posix()}#p1-2")
+    assert resolved2.exists()
+    assert anchor2 == "p1-2"
+
+    # Clean-relative ("chunks/...") resolution
+    resolved3, anchor3 = normalize_source_path(clean_file_rel.as_posix())
+    assert resolved3.exists()
+    assert anchor3 is None
+
+    # Spin up a test client and hit /v1/file for both
+    from fastapi.testclient import TestClient
+    client = TestClient(app_module.app)
+
+    r1 = client.get("/v1/file", params={"path": raw_file_rel.as_posix()})
+    assert r1.status_code == 200
+    assert "PIP Policy" in r1.text
+
+    r2 = client.get("/v1/file", params={"path": f'data/clean/{clean_file_rel.as_posix()}#p1-2'})
+    assert r2.status_code == 200
+    assert "Chunked content here" in r2.text
+
+def test_traversal_blocked(temp_data_dirs):
+    raw, clean = temp_data_dirs
+    # Create a harmless file outside the roots
+    outside = raw.parent / "outside.txt"
+    outside.write_text("nope", encoding="utf-8")
+
+    from app.paths import PathResolutionError, normalize_source_path
+    with pytest.raises(PathResolutionError):
+        normalize_source_path("../outside.txt")


### PR DESCRIPTION
What: Centralized file roots, safe path normalizer, updated /v1/file, tests, env/readme updates.
Why: Make citation links reliable and secure across raw/clean sources.
How to test: pytest -q; curl examples above.
Risks: Low—file serving is constrained to configured roots; traversal blocked.
Follow-ups: Consider returning structured JSON with snippets/paging if needed.